### PR TITLE
Refine Bootstrap styling for auth layout

### DIFF
--- a/static/css/auth.css
+++ b/static/css/auth.css
@@ -1,134 +1,135 @@
 /* ===== AUTHENTICATION STYLES ===== */
 
-/* Auth Header */
+body.auth-body {
+  background-color: #f3f4f6;
+  color: #111827;
+}
+
 .auth-header {
   background: #111827;
   color: #fff;
-  padding: 16px 20px;
+  padding: 20px;
   text-align: center;
   font-weight: 600;
   font-size: 22px;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 10px;
+  gap: 12px;
+  letter-spacing: 0.015em;
 }
 
 .auth-header .logo-icon {
-  font-size: 24px;
+  font-size: 26px;
 }
 
 .auth-header .logo-text {
-  font-family: 'Segoe UI', sans-serif;
+  font-family: "Segoe UI", sans-serif;
   font-weight: 600;
   font-size: 20px;
 }
 
-/* Auth Content */
 .auth-content {
+  padding: 48px 20px 64px;
+  min-height: calc(100vh - 84px);
   display: flex;
-  justify-content: center;
-  align-items: flex-start;
-  min-height: calc(100vh - 60px);
-  padding: 40px 20px;
-}
-
-.auth-container {
-  display: flex;
-  flex-direction: column;
   align-items: center;
+  justify-content: center;
+}
+
+.auth-content .container {
   width: 100%;
-  max-width: 400px;
-  margin: 0 auto;
 }
 
-/* Auth Flash Messages */
-.auth-flash {
-  width: 100%;
-  max-width: 350px;
-  margin-bottom: 20px;
+.auth-content .auth-card {
+  border-radius: 18px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 20px 40px -24px rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(0.5px);
 }
 
-.auth-flash .flash-item {
-  padding: 12px 16px;
-  border-radius: 8px;
-  margin-bottom: 8px;
-  font-weight: 500;
-  text-align: center;
-  width: 100%;
-  box-sizing: border-box;
+.auth-content .auth-card .card-body {
+  padding: 32px;
 }
 
-.auth-flash .flash-item.success {
-  background: #dcfce7;
-  color: #166534;
-  border: 1px solid #bbf7d0;
+.auth-content .h3,
+.auth-content h1,
+.auth-content h2,
+.auth-content h3 {
+  font-weight: 700;
+  color: #0f172a;
 }
 
-.auth-flash .flash-item.warning {
-  background: #fef3c7;
-  color: #92400e;
-  border: 1px solid #fde68a;
-}
-
-.auth-flash .flash-item.danger {
-  background: #fee2e2;
-  color: #991b1b;
-  border: 1px solid #fecaca;
-}
-
-.auth-flash .flash-item.info {
-  background: #dbeafe;
-  color: #1e40af;
-  border: 1px solid #bfdbfe;
-}
-
-/* Login Box */
-.login-box {
-  background: #fff;
-  padding: 24px 28px;
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  width: 100%;
-  max-width: 350px;
-  text-align: center;
-  margin: 0;
-}
-
-.login-box h2 {
-  margin-bottom: 20px;
-}
-
-.login-box label {
-  display: block;
-  text-align: left;
-  margin-bottom: 6px;
-  font-size: 14px;
-  color: #333;
-}
-
-.login-box input {
-  width: 100%;
-  margin-bottom: 14px;
-}
-
-/* Touch-friendly Styles */
-.login-box input,
-.login-box button,
-.login-box select {
-  min-height: 44px;
-  line-height: 1.2;
-  font-size: 1rem;
-}
-
-.login-box input {
-  padding: 10px 12px;
-}
-
-.login-box .btn,
-.login-box button[type="submit"] {
-  width: 100%;
-  padding: 12px 14px;
-  border-radius: 8px;
+.auth-content .form-label {
   font-weight: 600;
+  color: #1f2937;
+}
+
+.auth-content .form-control {
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid #cbd5f5;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  min-height: 48px;
+}
+
+.auth-content .form-control:focus {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 0.25rem rgba(37, 99, 235, 0.2);
+}
+
+.auth-content .btn-primary {
+  padding: 12px 16px;
+  border-radius: 12px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.auth-content .btn-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 30px -15px rgba(37, 99, 235, 0.55);
+}
+
+.auth-content .alert {
+  border-radius: 12px;
+  box-shadow: 0 10px 30px -24px rgba(15, 23, 42, 0.6);
+}
+
+.auth-content .link-secondary {
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.auth-content .link-secondary:hover,
+.auth-content .link-secondary:focus {
+  text-decoration: underline;
+}
+
+@media (max-width: 575.98px) {
+  .auth-header {
+    font-size: 18px;
+    padding: 16px;
+    gap: 8px;
+  }
+
+  .auth-header .logo-text {
+    font-size: 18px;
+  }
+
+  .auth-content {
+    padding: 32px 16px 48px;
+    min-height: calc(100vh - 72px);
+  }
+
+  .auth-content .auth-card .card-body {
+    padding: 24px;
+  }
+}
+
+@media (min-width: 992px) {
+  .auth-content {
+    padding-top: 72px;
+    padding-bottom: 96px;
+  }
 }

--- a/templates/auth_base.html
+++ b/templates/auth_base.html
@@ -4,50 +4,63 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
-    <title>Putera Barbershop</title>
+    <title>{% block title %}Putera Barbershop{% endblock %}</title>
+    <link rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+        integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+        crossorigin="anonymous">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/base.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/layout.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/components.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/auth.css') }}">
+    {% block extra_head %}{% endblock %}
 </head>
 
-<body>
-    <header class="auth-header">
+<body class="auth-body bg-light">
+    <header class="auth-header mb-4">
         <span class="logo-icon">💈</span>
         <span class="logo-text">Putera Barbershop</span>
     </header>
 
     <main class="auth-content">
-        <!-- Container utama yang memusatkan semua konten -->
-        <div class="auth-container">
-            <!-- Flash messages - ditempatkan di dalam container yang sama -->
-            {% with messages = get_flashed_messages(with_categories=true) %}
-            {% if messages %}
-            <div class="auth-flash">
-                {% for cat,msg in messages %}
-                <div class="flash-item {{ cat }}">{{ msg }}</div>
-                {% endfor %}
-            </div>
-            {% endif %}
-            {% endwith %}
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-12 col-md-8 col-lg-5 col-xl-4">
+                    {% with messages = get_flashed_messages(with_categories=true) %}
+                    {% if messages %}
+                    {% set bootstrap_mapping = {
+                        'error': 'danger',
+                        'message': 'info',
+                        'danger': 'danger',
+                        'warning': 'warning',
+                        'success': 'success'
+                    } %}
+                    <div class="mb-4">
+                        {% for cat, msg in messages %}
+                        {% set bootstrap_cat = bootstrap_mapping.get(cat, cat) %}
+                        <div class="alert alert-{{ bootstrap_cat }} alert-dismissible fade show" role="alert">
+                            {{ msg }}
+                            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                        </div>
+                        {% endfor %}
+                    </div>
+                    {% endif %}
+                    {% endwith %}
 
-            <div class="login-box">
-                <h2>Login</h2>
-                <form method="post">
-                    <label for="username">Username</label>
-                    <input type="text" id="username" name="username" required>
-
-                    <label for="password">Password</label>
-                    <input type="password" id="password" name="password" required>
-
-                    <button type="submit" class="btn">Login</button>
-                </form>
-                <div style="margin-top:1em;">
-                    <a href="{{ url_for('auth.forgot_password') }}">Lupa password?</a>
+                    <div class="card shadow-sm border-0 auth-card">
+                        <div class="card-body">
+                            {% block content %}{% endblock %}
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
     </main>
 
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
+        crossorigin="anonymous"></script>
+    {% block extra_scripts %}{% endblock %}
 </body>
 
 </html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,13 +1,19 @@
 {% extends 'auth_base.html' %}
 {% block title %}Masuk - Kapster Absen{% endblock %}
 {% block content %}
-<h1>Masuk</h1>
-<form method="post" class="form">
-    <label>Username<input type="text" name="username" required></label>
-    <label>Password<input type="password" name="password" required></label>
-    <button type="submit">Masuk</button>
+<h1 class="h3 text-center mb-4">Masuk</h1>
+<form method="post" class="needs-validation" novalidate>
+    <div class="mb-3">
+        <label class="form-label" for="username">Username</label>
+        <input type="text" class="form-control" id="username" name="username" required autofocus autocomplete="username">
+    </div>
+    <div class="mb-4">
+        <label class="form-label" for="password">Password</label>
+        <input type="password" class="form-control" id="password" name="password" required autocomplete="current-password">
+    </div>
+    <button type="submit" class="btn btn-primary w-100">Masuk</button>
 </form>
-<div style="margin-top:1em;">
-    <a href="{{ url_for('auth.forgot_password') }}">Lupa password?</a>
+<div class="text-center mt-3">
+    <a class="link-secondary" href="{{ url_for('auth.forgot_password') }}">Lupa password?</a>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- scope Bootstrap-ready styling to authentication pages by tagging the layout body and mapping flash categories once
- reshape the auth card grid wrapper and flash alert presentation for tighter Bootstrap integration
- refresh `static/css/auth.css` with Bootstrap-friendly spacing, form control, and responsive rules tailored to the new layout

## Testing
- flask run --host=0.0.0.0 --port=5000

------
https://chatgpt.com/codex/tasks/task_e_68deb89d56e8832384b5fe561fd72ed4